### PR TITLE
Fix logger handler level usage

### DIFF
--- a/logger_config.py
+++ b/logger_config.py
@@ -1,13 +1,25 @@
 import logging
-import os
 
-def setup_logger(name: str, level=logging.INFO):
+
+def setup_logger(name: str, level: int = logging.INFO):
+    """Create and configure a ``logging.Logger`` instance.
+
+    Parameters
+    ----------
+    name:
+        Name of the logger to configure.
+    level:
+        Logging level to apply to both the logger and its handler.
+    """
     logger = logging.getLogger(name)
     logger.setLevel(level)
     formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s')
-    # console handler
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.INFO)
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
+
+    # Avoid adding multiple handlers if ``setup_logger`` is called repeatedly
+    if not logger.handlers:
+        ch = logging.StreamHandler()
+        ch.setLevel(level)
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+
     return logger


### PR DESCRIPTION
## Summary
- ensure `setup_logger` applies the requested logging level to the handler
- prevent duplicate handlers when configuring loggers

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689636921d7c832c846e3cfe4043526b